### PR TITLE
Add Symfony 8 support and fix POST bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,12 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "luft-jetzt/luft-model": "^0.5.1",
-        "symfony/http-client": "^7.1",
-        "symfony/serializer": "^7.1",
-        "symfony/dependency-injection": "^7.1",
-        "symfony/property-access": "^7.1"
+        "symfony/http-client": "^7.4 || ^8.0",
+        "symfony/serializer": "^7.4 || ^8.0",
+        "symfony/dependency-injection": "^7.4 || ^8.0",
+        "symfony/property-access": "^7.4 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Client/ApiClient.php
+++ b/src/Client/ApiClient.php
@@ -26,7 +26,7 @@ class ApiClient implements ApiClientInterface
 
     public function post($uri, array $options = []): ResponseInterface
     {
-        return $this->httpClient->request('GET', $uri, $options);
+        return $this->httpClient->request('POST', $uri, $options);
     }
 
     public function get($uri, array $options = []): ResponseInterface


### PR DESCRIPTION
## Summary
- Widens Symfony version constraints to `^7.4 || ^8.0` for all dependencies
- Raises minimum PHP to `^8.4`
- Fixes `ApiClient::post()` which incorrectly used HTTP `GET` instead of `POST`

## Test plan
- [x] `composer require --dry-run` confirms Symfony 8 packages install
- [x] Code review: no Symfony 8 breaking changes in bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)