### PR TITLE
Exclude Resources directory from service auto-registration

### DIFF
--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -9,5 +9,5 @@ return static function (ContainerConfigurator $container): void {
             ->autoconfigure();
 
     $services->load('Caldera\\LuftApiBundle\\', '../../*')
-        ->exclude('../../{DependencyInjection,Entity,Tests,Kernel.php}');
+        ->exclude('../../{DependencyInjection,Entity,Resources,Tests,Kernel.php}');
 };


### PR DESCRIPTION
## Summary
The resource glob `../../*` in `services.php` was including the file itself, causing a "class not found" error when the container builder tried to register it as a service. Adds `Resources` to the exclusion list.

## Test plan
- [x] `php bin/console luft:fetch` no longer throws class-not-found error

🤖 Generated with [Claude Code](https://claude.com/claude-code)