### PR TITLE
[Hoch] TLS standardmäßig aktiv, Bearer-Token-Unterstützung, Config-Härtung

### DIFF
--- a/src/Client/ApiClient.php
+++ b/src/Client/ApiClient.php
@@ -10,13 +10,19 @@ class ApiClient implements ApiClientInterface
 {
     protected HttpClientInterface $httpClient;
 
-    public function __construct(string $hostname, int $port, bool $verify)
+    public function __construct(string $hostname, int $port, bool $verify, string $token = '')
     {
-        $this->httpClient = HttpClient::create([
+        $options = [
             'base_uri' => sprintf('https://%s:%d/', $hostname, $port),
             'verify_peer' => $verify,
             'verify_host' => $verify,
-        ]);
+        ];
+
+        if ('' !== $token) {
+            $options['auth_bearer'] = $token;
+        }
+
+        $this->httpClient = HttpClient::create($options);
     }
 
     public function put($uri, array $options = []): ResponseInterface

--- a/src/DependencyInjection/CalderaLuftApiExtension.php
+++ b/src/DependencyInjection/CalderaLuftApiExtension.php
@@ -23,6 +23,7 @@ class CalderaLuftApiExtension extends Extension
         $definition->setArgument(0, (string) $config['api']['hostname']);
         $definition->setArgument(1, (int) $config['api']['port']);
         $definition->setArgument(2, (bool) $config['api']['verify']);
+        $definition->setArgument(3, (string) $config['api']['token']);
     }
 
     public function getAlias(): string

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -15,10 +15,13 @@ class Configuration implements ConfigurationInterface
             ->getRootNode()
             ->children()
             ->arrayNode('api')
+            ->isRequired()
             ->children()
-            ->scalarNode('hostname')->cannotBeEmpty()->end()
-            ->scalarNode('port')->end()
-            ->booleanNode('verify')->end()
+            ->scalarNode('hostname')->isRequired()->cannotBeEmpty()->end()
+            ->integerNode('port')->min(1)->max(65535)->defaultValue(443)->end()
+            ->booleanNode('verify')->defaultTrue()->end()
+            ->scalarNode('token')->defaultValue('')->end()
+            ->end()
             ->end()
             ->end();
 


### PR DESCRIPTION
Behebt #28 und liefert die Client-Seite zu luft-jetzt/luft-app#522.

## Änderungen
**`Configuration.php`**
- `verify`: `defaultTrue()` — bisher fehlte ein Default; in `CalderaLuftApiExtension` führte `(bool) null === false` dazu, dass die **TLS-Prüfung standardmäßig deaktiviert** war (MITM-Risiko).
- `port`: `integerNode()->min(1)->max(65535)->defaultValue(443)` — bisher konnte `(int) null === 0` einen ungültigen Port erzeugen.
- `api` und `hostname`: `isRequired()` — Fehlkonfiguration früh abfangen.
- Neuer optionaler `token`-Knoten.

**`ApiClient.php`**
- Optionaler vierter Konstruktor-Parameter `string $token = ''`. Ist er gesetzt, wird `auth_bearer` (→ `Authorization: Bearer <token>`) an **jeden** Request gehängt. Leeres Token = kein Header (Bestandsverhalten).

**`CalderaLuftApiExtension.php`**
- Reicht `api.token` als 4. Argument an den `ApiClient` durch.

## Aktivierung in den Providern
```yaml
caldera_luftapi:
    api:
        hostname: luft.jetzt
        port: 443
        verify: true
        token: '%env(LUFT_API_TOKEN)%'   # neu — dasselbe Token wie in luft-app
```

## Kompatibilität
Die vorhandenen Provider-Konfigs setzen `verify` bereits explizit (z. B. `verify: true` in prod, `verify: false` für localhost-dev), sind vom neuen Default also nicht betroffen. `token` ist optional und defaultet auf `''`.

## Verifikation
Standalone gegen den Symfony Config-Processor geprüft: Defaults (`port=443`, `verify=true`, `token=''`), Port-Range-Validierung, `api`/`hostname` required, sowie `ApiClient`-Instanziierung mit und ohne Token (`auth_bearer` akzeptiert).

## Hinweis (Folge-Thema, nicht in diesem PR)
Das Bundle nutzt `symfony/config` (TreeBuilder) und `symfony/http-kernel` (Extension-Basisklasse), deklariert beide aber nicht in `composer.json` require — funktioniert nur, weil die Host-App sie bereitstellt. Sollte separat ergänzt werden.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)